### PR TITLE
feat: Themed icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/white" />
     <foreground android:drawable="@drawable/icon_color" />
+    <monochrome android:drawable="@drawable/icon_color" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/white" />
     <foreground android:drawable="@drawable/icon_color" />
+    <monochrome android:drawable="@drawable/icon_color" />
 </adaptive-icon>


### PR DESCRIPTION
## This PR adds the Themed Icon feature introduced in [Android 13](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

### Examples:

- #### Normal icon for reference

  ####
  #### <img src="https://github.com/user-attachments/assets/193d0baf-d4d4-475c-a0f5-59106d7e7dc2" width="20%"/>

- #### Light Theme, Light Green Palette
  ####
  #### <img src="https://github.com/user-attachments/assets/ac13ac7c-7cb3-4501-9641-731b707940f8" width="20%"/>

- #### Dark Theme, Light Green Palette
  ####
  #### <img src="https://github.com/user-attachments/assets/e84ed890-4d95-49d3-9665-d26a2be492eb" width="20%"/>